### PR TITLE
 Fix missing settings (take two)

### DIFF
--- a/depends/common/pcsx-rearmed/0001-Force-enable-NEON-and-Dynarec-settings.patch
+++ b/depends/common/pcsx-rearmed/0001-Force-enable-NEON-and-Dynarec-settings.patch
@@ -1,0 +1,52 @@
+From e93f09e5fd8c2a064215e66e44598f4ec58ff832 Mon Sep 17 00:00:00 2001
+From: Garrett Brown <themagnificentmrb@gmail.com>
+Date: Thu, 20 May 2021 16:11:18 -0700
+Subject: [PATCH] Force-enable NEON and Dynarec settings
+
+---
+ frontend/libretro_core_options.h | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/frontend/libretro_core_options.h b/frontend/libretro_core_options.h
+index 813e30a..d316c25 100644
+--- a/frontend/libretro_core_options.h
++++ b/frontend/libretro_core_options.h
+@@ -479,7 +479,7 @@ struct retro_core_option_definition option_defs_us[] = {
+ #endif
+    },
+ 
+-#if defined(LIGHTREC) || defined(NEW_DYNAREC)
++#if true
+    {
+       "pcsx_rearmed_drc",
+       "Dynamic Recompiler",
+@@ -493,7 +493,7 @@ struct retro_core_option_definition option_defs_us[] = {
+    },
+ #endif /* LIGHTREC || NEW_DYNAREC */
+ 
+-#ifdef NEW_DYNAREC
++#if true
+    {
+       "pcsx_rearmed_psxclock",
+       "PSX CPU Clock",
+@@ -584,7 +584,7 @@ struct retro_core_option_definition option_defs_us[] = {
+    },
+ #endif /* NEW_DYNAREC */
+ 
+-#ifdef GPU_NEON
++#if true
+    {
+       "pcsx_rearmed_neon_interlace_enable",
+       "Enable Interlacing Mode",
+@@ -969,7 +969,7 @@ struct retro_core_option_definition option_defs_us[] = {
+       "disabled",
+    },
+ 
+-#ifdef NEW_DYNAREC
++#if true
+    {
+       "pcsx_rearmed_nosmccheck",
+       "(Speed Hack) Disable SMC Checks",
+-- 
+2.30.2
+

--- a/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
+++ b/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
@@ -21,157 +21,157 @@ msgid "Settings"
 msgstr ""
 
 msgctxt "#30001"
-msgid "Analog axis bounds."
-msgstr ""
-
-msgctxt "#30002"
-msgid "CD Access Method (Restart)"
-msgstr ""
-
-msgctxt "#30003"
-msgid "Use BIOS"
-msgstr ""
-
-msgctxt "#30004"
-msgid "Display Internal FPS"
-msgstr ""
-
-msgctxt "#30005"
-msgid "Enable Dithering"
-msgstr ""
-
-msgctxt "#30006"
-msgid "Dynamic Recompiler"
-msgstr ""
-
-msgctxt "#30007"
-msgid "Frame Duping"
-msgstr ""
-
-msgctxt "#30008"
 msgid "Frameskip"
 msgstr ""
 
-msgctxt "#30009"
-msgid "(GPU) Disable Coordinate Check"
+msgctxt "#30002"
+msgid "Use BIOS"
 msgstr ""
 
-msgctxt "#30010"
-msgid "(GPU) Expand Screen Width"
-msgstr ""
-
-msgctxt "#30011"
-msgid "(GPU) Fake 'Gpu Busy' States"
-msgstr ""
-
-msgctxt "#30012"
-msgid "(GPU) Ignore Brightness Color"
-msgstr ""
-
-msgctxt "#30013"
-msgid "(GPU) Lazy Screen Update"
-msgstr ""
-
-msgctxt "#30014"
-msgid "(GPU) Odd/Even Bit Hack"
-msgstr ""
-
-msgctxt "#30015"
-msgid "(GPU) Old Frame Skipping"
-msgstr ""
-
-msgctxt "#30016"
-msgid "(GPU) Draw Quads with Triangles"
-msgstr ""
-
-msgctxt "#30017"
-msgid "(GPU) Repeated Flat Tex Triangles"
-msgstr ""
-
-msgctxt "#30018"
-msgid "Threaded Rendering"
-msgstr ""
-
-msgctxt "#30019"
-msgid "Guncon Adjust Ratio X"
-msgstr ""
-
-msgctxt "#30020"
-msgid "Guncon Adjust Ratio Y"
-msgstr ""
-
-msgctxt "#30021"
-msgid "Guncon Adjust X"
-msgstr ""
-
-msgctxt "#30022"
-msgid "Guncon Adjust Y"
-msgstr ""
-
-msgctxt "#30023"
-msgid "Diablo Music Fix"
-msgstr ""
-
-msgctxt "#30024"
-msgid "Emulated Mouse Sensitivity"
-msgstr ""
-
-msgctxt "#30025"
-msgid "InuYasha Sengoku Battle Fix"
-msgstr ""
-
-msgctxt "#30026"
-msgid "Enable Second Memory Card (Shared)"
-msgstr ""
-
-msgctxt "#30027"
-msgid "Multitap Mode (Restart)"
-msgstr ""
-
-msgctxt "#30028"
-msgid "NegCon Twist Deadzone (Percent)"
-msgstr ""
-
-msgctxt "#30029"
-msgid "NegCon Twist Response"
-msgstr ""
-
-msgctxt "#30030"
-msgid "CD Audio"
-msgstr ""
-
-msgctxt "#30031"
-msgid "XA Decoding"
-msgstr ""
-
-msgctxt "#30032"
-msgid "Parasite Eve 2/Vandal Hearts 1/2 Fix"
-msgstr ""
-
-msgctxt "#30033"
+msgctxt "#30003"
 msgid "Region"
 msgstr ""
 
-msgctxt "#30034"
-msgid "Show Bios Bootlogo"
+msgctxt "#30004"
+msgid "Enable Second Memory Card (Shared)"
 msgstr ""
 
-msgctxt "#30035"
+msgctxt "#30005"
 msgid "Show other input settings"
 msgstr ""
 
-msgctxt "#30036"
-msgid "Sound Interpolation"
+msgctxt "#30006"
+msgid "Emulated Mouse Sensitivity"
 msgstr ""
 
-msgctxt "#30037"
+msgctxt "#30007"
+msgid "Multitap Mode (Restart)"
+msgstr ""
+
+msgctxt "#30008"
+msgid "NegCon Twist Deadzone (Percent)"
+msgstr ""
+
+msgctxt "#30009"
+msgid "NegCon Twist Response"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Analog axis bounds."
+msgstr ""
+
+msgctxt "#30011"
+msgid "Enable Vibration"
+msgstr ""
+
+msgctxt "#30012"
+msgid "Guncon Adjust X"
+msgstr ""
+
+msgctxt "#30013"
+msgid "Guncon Adjust Y"
+msgstr ""
+
+msgctxt "#30014"
+msgid "Guncon Adjust Ratio X"
+msgstr ""
+
+msgctxt "#30015"
+msgid "Guncon Adjust Ratio Y"
+msgstr ""
+
+msgctxt "#30016"
+msgid "Enable Dithering"
+msgstr ""
+
+msgctxt "#30017"
+msgid "Dynamic Recompiler"
+msgstr ""
+
+msgctxt "#30018"
+msgid "Frame Duping"
+msgstr ""
+
+msgctxt "#30019"
+msgid "Display Internal FPS"
+msgstr ""
+
+msgctxt "#30020"
+msgid "(GPU) Odd/Even Bit Hack"
+msgstr ""
+
+msgctxt "#30021"
+msgid "(GPU) Expand Screen Width"
+msgstr ""
+
+msgctxt "#30022"
+msgid "(GPU) Ignore Brightness Color"
+msgstr ""
+
+msgctxt "#30023"
+msgid "(GPU) Disable Coordinate Check"
+msgstr ""
+
+msgctxt "#30024"
+msgid "(GPU) Lazy Screen Update"
+msgstr ""
+
+msgctxt "#30025"
+msgid "(GPU) Old Frame Skipping"
+msgstr ""
+
+msgctxt "#30026"
+msgid "(GPU) Repeated Flat Tex Triangles"
+msgstr ""
+
+msgctxt "#30027"
+msgid "(GPU) Draw Quads with Triangles"
+msgstr ""
+
+msgctxt "#30028"
+msgid "(GPU) Fake 'Gpu Busy' States"
+msgstr ""
+
+msgctxt "#30029"
+msgid "Threaded Rendering"
+msgstr ""
+
+msgctxt "#30030"
+msgid "Show Bios Bootlogo"
+msgstr ""
+
+msgctxt "#30031"
 msgid "Sound Reverb"
 msgstr ""
 
+msgctxt "#30032"
+msgid "Sound Interpolation"
+msgstr ""
+
+msgctxt "#30033"
+msgid "Diablo Music Fix"
+msgstr ""
+
+msgctxt "#30034"
+msgid "Parasite Eve 2/Vandal Hearts 1/2 Fix"
+msgstr ""
+
+msgctxt "#30035"
+msgid "InuYasha Sengoku Battle Fix"
+msgstr ""
+
+msgctxt "#30036"
+msgid "CD Access Method (Restart)"
+msgstr ""
+
+msgctxt "#30037"
+msgid "XA Decoding"
+msgstr ""
+
 msgctxt "#30038"
-msgid "SPU IRQ Always Enabled"
+msgid "CD Audio"
 msgstr ""
 
 msgctxt "#30039"
-msgid "Enable Vibration"
+msgid "SPU IRQ Always Enabled"
 msgstr ""

--- a/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
+++ b/game.libretro.pcsx-rearmed/resources/language/resource.language.en_gb/strings.po
@@ -89,89 +89,117 @@ msgid "Dynamic Recompiler"
 msgstr ""
 
 msgctxt "#30018"
-msgid "Frame Duping"
+msgid "PSX CPU Clock"
 msgstr ""
 
 msgctxt "#30019"
-msgid "Display Internal FPS"
+msgid "Enable Interlacing Mode"
 msgstr ""
 
 msgctxt "#30020"
-msgid "(GPU) Odd/Even Bit Hack"
+msgid "Enhanced Resolution (Slow)"
 msgstr ""
 
 msgctxt "#30021"
-msgid "(GPU) Expand Screen Width"
+msgid "Enhanced Resolution (Speed Hack)"
 msgstr ""
 
 msgctxt "#30022"
-msgid "(GPU) Ignore Brightness Color"
+msgid "Frame Duping"
 msgstr ""
 
 msgctxt "#30023"
-msgid "(GPU) Disable Coordinate Check"
+msgid "Display Internal FPS"
 msgstr ""
 
 msgctxt "#30024"
-msgid "(GPU) Lazy Screen Update"
+msgid "(GPU) Odd/Even Bit Hack"
 msgstr ""
 
 msgctxt "#30025"
-msgid "(GPU) Old Frame Skipping"
+msgid "(GPU) Expand Screen Width"
 msgstr ""
 
 msgctxt "#30026"
-msgid "(GPU) Repeated Flat Tex Triangles"
+msgid "(GPU) Ignore Brightness Color"
 msgstr ""
 
 msgctxt "#30027"
-msgid "(GPU) Draw Quads with Triangles"
+msgid "(GPU) Disable Coordinate Check"
 msgstr ""
 
 msgctxt "#30028"
-msgid "(GPU) Fake 'Gpu Busy' States"
+msgid "(GPU) Lazy Screen Update"
 msgstr ""
 
 msgctxt "#30029"
-msgid "Threaded Rendering"
+msgid "(GPU) Old Frame Skipping"
 msgstr ""
 
 msgctxt "#30030"
-msgid "Show Bios Bootlogo"
+msgid "(GPU) Repeated Flat Tex Triangles"
 msgstr ""
 
 msgctxt "#30031"
-msgid "Sound Reverb"
+msgid "(GPU) Draw Quads with Triangles"
 msgstr ""
 
 msgctxt "#30032"
-msgid "Sound Interpolation"
+msgid "(GPU) Fake 'Gpu Busy' States"
 msgstr ""
 
 msgctxt "#30033"
-msgid "Diablo Music Fix"
+msgid "Threaded Rendering"
 msgstr ""
 
 msgctxt "#30034"
-msgid "Parasite Eve 2/Vandal Hearts 1/2 Fix"
+msgid "Show Bios Bootlogo"
 msgstr ""
 
 msgctxt "#30035"
-msgid "InuYasha Sengoku Battle Fix"
+msgid "Sound Reverb"
 msgstr ""
 
 msgctxt "#30036"
-msgid "CD Access Method (Restart)"
+msgid "Sound Interpolation"
 msgstr ""
 
 msgctxt "#30037"
-msgid "XA Decoding"
+msgid "Diablo Music Fix"
 msgstr ""
 
 msgctxt "#30038"
-msgid "CD Audio"
+msgid "Parasite Eve 2/Vandal Hearts 1/2 Fix"
 msgstr ""
 
 msgctxt "#30039"
+msgid "InuYasha Sengoku Battle Fix"
+msgstr ""
+
+msgctxt "#30040"
+msgid "CD Access Method (Restart)"
+msgstr ""
+
+msgctxt "#30041"
+msgid "XA Decoding"
+msgstr ""
+
+msgctxt "#30042"
+msgid "CD Audio"
+msgstr ""
+
+msgctxt "#30043"
 msgid "SPU IRQ Always Enabled"
+msgstr ""
+
+msgctxt "#30044"
+msgid "(Speed Hack) Disable SMC Checks"
+msgstr ""
+
+msgctxt "#30045"
+msgid "(Speed Hack) Assume GTE Regs Unneeded"
+msgstr ""
+
+msgctxt "#30046"
+msgid "(Speed Hack) Disable GTE Flags"
 msgstr ""

--- a/game.libretro.pcsx-rearmed/resources/settings.xml
+++ b/game.libretro.pcsx-rearmed/resources/settings.xml
@@ -18,27 +18,34 @@
 		<setting label="30015" type="select" id="pcsx_rearmed_gunconadjustratioy" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
 		<setting label="30016" type="select" id="pcsx_rearmed_dithering" values="enabled|disabled" default="enabled"/>
 		<setting label="30017" type="select" id="pcsx_rearmed_drc" values="enabled|disabled" default="enabled"/>
-		<setting label="30018" type="select" id="pcsx_rearmed_duping_enable" values="enabled|disabled" default="enabled"/>
-		<setting label="30019" type="select" id="pcsx_rearmed_display_internal_fps" values="disabled|enabled" default="disabled"/>
-		<setting label="30020" type="select" id="pcsx_rearmed_gpu_peops_odd_even_bit" values="disabled|enabled" default="disabled"/>
-		<setting label="30021" type="select" id="pcsx_rearmed_gpu_peops_expand_screen_width" values="disabled|enabled" default="disabled"/>
-		<setting label="30022" type="select" id="pcsx_rearmed_gpu_peops_ignore_brightness" values="disabled|enabled" default="disabled"/>
-		<setting label="30023" type="select" id="pcsx_rearmed_gpu_peops_disable_coord_check" values="disabled|enabled" default="disabled"/>
-		<setting label="30024" type="select" id="pcsx_rearmed_gpu_peops_lazy_screen_update" values="disabled|enabled" default="disabled"/>
-		<setting label="30025" type="select" id="pcsx_rearmed_gpu_peops_old_frame_skip" values="enabled|disabled" default="enabled"/>
-		<setting label="30026" type="select" id="pcsx_rearmed_gpu_peops_repeated_triangles" values="disabled|enabled" default="disabled"/>
-		<setting label="30027" type="select" id="pcsx_rearmed_gpu_peops_quads_with_triangles" values="disabled|enabled" default="disabled"/>
-		<setting label="30028" type="select" id="pcsx_rearmed_gpu_peops_fake_busy_state" values="disabled|enabled" default="disabled"/>
-		<setting label="30029" type="select" id="pcsx_rearmed_gpu_thread_rendering" values="disabled|sync|async" default="disabled"/>
-		<setting label="30030" type="select" id="pcsx_rearmed_show_bios_bootlogo" values="disabled|enabled" default="disabled"/>
-		<setting label="30031" type="select" id="pcsx_rearmed_spu_reverb" values="enabled|disabled" default="enabled"/>
-		<setting label="30032" type="select" id="pcsx_rearmed_spu_interpolation" values="simple|gaussian|cubic|off" default="simple"/>
-		<setting label="30033" type="select" id="pcsx_rearmed_idiablofix" values="disabled|enabled" default="disabled"/>
-		<setting label="30034" type="select" id="pcsx_rearmed_pe2_fix" values="disabled|enabled" default="disabled"/>
-		<setting label="30035" type="select" id="pcsx_rearmed_inuyasha_fix" values="disabled|enabled" default="disabled"/>
-		<setting label="30036" type="select" id="pcsx_rearmed_async_cd" values="sync|async|precache" default="sync"/>
-		<setting label="30037" type="select" id="pcsx_rearmed_noxadecoding" values="enabled|disabled" default="enabled"/>
-		<setting label="30038" type="select" id="pcsx_rearmed_nocdaudio" values="enabled|disabled" default="enabled"/>
-		<setting label="30039" type="select" id="pcsx_rearmed_spuirq" values="disabled|enabled" default="disabled"/>
+		<setting label="30018" type="select" id="pcsx_rearmed_psxclock" values="57|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|58|59|60|61|62|63|64|65|66|67|68|69|70|71|72|73|74|75|76|77|78|79|80|81|82|83|84|85|86|87|88|89|90|91|92|93|94|95|96|97|98|99|100" default="57"/>
+		<setting label="30019" type="select" id="pcsx_rearmed_neon_interlace_enable" values="disabled|enabled" default="disabled"/>
+		<setting label="30020" type="select" id="pcsx_rearmed_neon_enhancement_enable" values="disabled|enabled" default="disabled"/>
+		<setting label="30021" type="select" id="pcsx_rearmed_neon_enhancement_no_main" values="disabled|enabled" default="disabled"/>
+		<setting label="30022" type="select" id="pcsx_rearmed_duping_enable" values="enabled|disabled" default="enabled"/>
+		<setting label="30023" type="select" id="pcsx_rearmed_display_internal_fps" values="disabled|enabled" default="disabled"/>
+		<setting label="30024" type="select" id="pcsx_rearmed_gpu_peops_odd_even_bit" values="disabled|enabled" default="disabled"/>
+		<setting label="30025" type="select" id="pcsx_rearmed_gpu_peops_expand_screen_width" values="disabled|enabled" default="disabled"/>
+		<setting label="30026" type="select" id="pcsx_rearmed_gpu_peops_ignore_brightness" values="disabled|enabled" default="disabled"/>
+		<setting label="30027" type="select" id="pcsx_rearmed_gpu_peops_disable_coord_check" values="disabled|enabled" default="disabled"/>
+		<setting label="30028" type="select" id="pcsx_rearmed_gpu_peops_lazy_screen_update" values="disabled|enabled" default="disabled"/>
+		<setting label="30029" type="select" id="pcsx_rearmed_gpu_peops_old_frame_skip" values="enabled|disabled" default="enabled"/>
+		<setting label="30030" type="select" id="pcsx_rearmed_gpu_peops_repeated_triangles" values="disabled|enabled" default="disabled"/>
+		<setting label="30031" type="select" id="pcsx_rearmed_gpu_peops_quads_with_triangles" values="disabled|enabled" default="disabled"/>
+		<setting label="30032" type="select" id="pcsx_rearmed_gpu_peops_fake_busy_state" values="disabled|enabled" default="disabled"/>
+		<setting label="30033" type="select" id="pcsx_rearmed_gpu_thread_rendering" values="disabled|sync|async" default="disabled"/>
+		<setting label="30034" type="select" id="pcsx_rearmed_show_bios_bootlogo" values="disabled|enabled" default="disabled"/>
+		<setting label="30035" type="select" id="pcsx_rearmed_spu_reverb" values="enabled|disabled" default="enabled"/>
+		<setting label="30036" type="select" id="pcsx_rearmed_spu_interpolation" values="simple|gaussian|cubic|off" default="simple"/>
+		<setting label="30037" type="select" id="pcsx_rearmed_idiablofix" values="disabled|enabled" default="disabled"/>
+		<setting label="30038" type="select" id="pcsx_rearmed_pe2_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30039" type="select" id="pcsx_rearmed_inuyasha_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30040" type="select" id="pcsx_rearmed_async_cd" values="sync|async|precache" default="sync"/>
+		<setting label="30041" type="select" id="pcsx_rearmed_noxadecoding" values="enabled|disabled" default="enabled"/>
+		<setting label="30042" type="select" id="pcsx_rearmed_nocdaudio" values="enabled|disabled" default="enabled"/>
+		<setting label="30043" type="select" id="pcsx_rearmed_spuirq" values="disabled|enabled" default="disabled"/>
+		<setting label="30044" type="select" id="pcsx_rearmed_nosmccheck" values="disabled|enabled" default="disabled"/>
+		<setting label="30045" type="select" id="pcsx_rearmed_gteregsunneeded" values="disabled|enabled" default="disabled"/>
+		<setting label="30046" type="select" id="pcsx_rearmed_nogteflags" values="disabled|enabled" default="disabled"/>
 	</category>
 </settings>

--- a/game.libretro.pcsx-rearmed/resources/settings.xml
+++ b/game.libretro.pcsx-rearmed/resources/settings.xml
@@ -1,44 +1,44 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 	<category label="30000">
-		<setting label="30001" type="select" id="pcsx_rearmed_analog_axis_modifier" values="circle|square" default="circle"/>
-		<setting label="30002" type="select" id="pcsx_rearmed_async_cd" values="sync|async|precache" default="sync"/>
-		<setting label="30003" type="select" id="pcsx_rearmed_bios" values="auto|HLE" default="auto"/>
-		<setting label="30004" type="select" id="pcsx_rearmed_display_internal_fps" values="disabled|enabled" default="disabled"/>
-		<setting label="30005" type="select" id="pcsx_rearmed_dithering" values="enabled|disabled" default="enabled"/>
-		<setting label="30006" type="select" id="pcsx_rearmed_drc" values="enabled|disabled" default="enabled"/>
-		<setting label="30007" type="select" id="pcsx_rearmed_duping_enable" values="enabled|disabled" default="enabled"/>
-		<setting label="30008" type="select" id="pcsx_rearmed_frameskip" values="0|1|2|3" default="0"/>
-		<setting label="30009" type="select" id="pcsx_rearmed_gpu_peops_disable_coord_check" values="disabled|enabled" default="disabled"/>
-		<setting label="30010" type="select" id="pcsx_rearmed_gpu_peops_expand_screen_width" values="disabled|enabled" default="disabled"/>
-		<setting label="30011" type="select" id="pcsx_rearmed_gpu_peops_fake_busy_state" values="disabled|enabled" default="disabled"/>
-		<setting label="30012" type="select" id="pcsx_rearmed_gpu_peops_ignore_brightness" values="disabled|enabled" default="disabled"/>
-		<setting label="30013" type="select" id="pcsx_rearmed_gpu_peops_lazy_screen_update" values="disabled|enabled" default="disabled"/>
-		<setting label="30014" type="select" id="pcsx_rearmed_gpu_peops_odd_even_bit" values="disabled|enabled" default="disabled"/>
-		<setting label="30015" type="select" id="pcsx_rearmed_gpu_peops_old_frame_skip" values="enabled|disabled" default="enabled"/>
-		<setting label="30016" type="select" id="pcsx_rearmed_gpu_peops_quads_with_triangles" values="disabled|enabled" default="disabled"/>
-		<setting label="30017" type="select" id="pcsx_rearmed_gpu_peops_repeated_triangles" values="disabled|enabled" default="disabled"/>
-		<setting label="30018" type="select" id="pcsx_rearmed_gpu_thread_rendering" values="disabled|sync|async" default="disabled"/>
-		<setting label="30019" type="select" id="pcsx_rearmed_gunconadjustratiox" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
-		<setting label="30020" type="select" id="pcsx_rearmed_gunconadjustratioy" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
-		<setting label="30021" type="select" id="pcsx_rearmed_gunconadjustx" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
-		<setting label="30022" type="select" id="pcsx_rearmed_gunconadjusty" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
-		<setting label="30023" type="select" id="pcsx_rearmed_idiablofix" values="disabled|enabled" default="disabled"/>
-		<setting label="30024" type="select" id="pcsx_rearmed_input_sensitivity" values="1.00|0.05|0.10|0.15|0.20|0.25|0.30|0.35|0.40|0.45|0.50|0.55|0.60|0.65|0.70|0.75|0.80|0.85|0.90|0.95|1.05|1.10|1.15|1.20|1.25|1.30|1.35|1.40|1.45|1.50|1.55|1.60|1.65|1.70|1.75|1.80|1.85|1.90|1.95|2.00" default="1.00"/>
-		<setting label="30025" type="select" id="pcsx_rearmed_inuyasha_fix" values="disabled|enabled" default="disabled"/>
-		<setting label="30026" type="select" id="pcsx_rearmed_memcard2" values="disabled|enabled" default="disabled"/>
-		<setting label="30027" type="select" id="pcsx_rearmed_multitap" values="disabled|port 1|port 2|ports 1 and 2" default="disabled"/>
-		<setting label="30028" type="select" id="pcsx_rearmed_negcon_deadzone" values="0|5|10|15|20|25|30" default="0"/>
-		<setting label="30029" type="select" id="pcsx_rearmed_negcon_response" values="linear|quadratic|cubic" default="linear"/>
-		<setting label="30030" type="select" id="pcsx_rearmed_nocdaudio" values="enabled|disabled" default="enabled"/>
-		<setting label="30031" type="select" id="pcsx_rearmed_noxadecoding" values="enabled|disabled" default="enabled"/>
-		<setting label="30032" type="select" id="pcsx_rearmed_pe2_fix" values="disabled|enabled" default="disabled"/>
-		<setting label="30033" type="select" id="pcsx_rearmed_region" values="auto|NTSC|PAL" default="auto"/>
-		<setting label="30034" type="select" id="pcsx_rearmed_show_bios_bootlogo" values="disabled|enabled" default="disabled"/>
-		<setting label="30035" type="select" id="pcsx_rearmed_show_other_input_settings" values="disabled|enabled" default="disabled"/>
-		<setting label="30036" type="select" id="pcsx_rearmed_spu_interpolation" values="simple|gaussian|cubic|off" default="simple"/>
-		<setting label="30037" type="select" id="pcsx_rearmed_spu_reverb" values="enabled|disabled" default="enabled"/>
-		<setting label="30038" type="select" id="pcsx_rearmed_spuirq" values="disabled|enabled" default="disabled"/>
-		<setting label="30039" type="select" id="pcsx_rearmed_vibration" values="enabled|disabled" default="enabled"/>
+		<setting label="30001" type="select" id="pcsx_rearmed_frameskip" values="0|1|2|3" default="0"/>
+		<setting label="30002" type="select" id="pcsx_rearmed_bios" values="auto|HLE" default="auto"/>
+		<setting label="30003" type="select" id="pcsx_rearmed_region" values="auto|NTSC|PAL" default="auto"/>
+		<setting label="30004" type="select" id="pcsx_rearmed_memcard2" values="disabled|enabled" default="disabled"/>
+		<setting label="30005" type="select" id="pcsx_rearmed_show_other_input_settings" values="disabled|enabled" default="disabled"/>
+		<setting label="30006" type="select" id="pcsx_rearmed_input_sensitivity" values="1.00|0.05|0.10|0.15|0.20|0.25|0.30|0.35|0.40|0.45|0.50|0.55|0.60|0.65|0.70|0.75|0.80|0.85|0.90|0.95|1.05|1.10|1.15|1.20|1.25|1.30|1.35|1.40|1.45|1.50|1.55|1.60|1.65|1.70|1.75|1.80|1.85|1.90|1.95|2.00" default="1.00"/>
+		<setting label="30007" type="select" id="pcsx_rearmed_multitap" values="disabled|port 1|port 2|ports 1 and 2" default="disabled"/>
+		<setting label="30008" type="select" id="pcsx_rearmed_negcon_deadzone" values="0|5|10|15|20|25|30" default="0"/>
+		<setting label="30009" type="select" id="pcsx_rearmed_negcon_response" values="linear|quadratic|cubic" default="linear"/>
+		<setting label="30010" type="select" id="pcsx_rearmed_analog_axis_modifier" values="circle|square" default="circle"/>
+		<setting label="30011" type="select" id="pcsx_rearmed_vibration" values="enabled|disabled" default="enabled"/>
+		<setting label="30012" type="select" id="pcsx_rearmed_gunconadjustx" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
+		<setting label="30013" type="select" id="pcsx_rearmed_gunconadjusty" values="0|-25|-24|-23|-22|-21|-20|-19|-18|-17|-16|-15|-14|-13|-12|-11|-10|-09|-08|-07|-06|-05|-04|-03|-02|-01|00|01|02|03|04|05|06|07|08|09|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25" default="0"/>
+		<setting label="30014" type="select" id="pcsx_rearmed_gunconadjustratiox" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
+		<setting label="30015" type="select" id="pcsx_rearmed_gunconadjustratioy" values="1|0.75|0.76|0.77|0.78|0.79|0.80|0.81|0.82|0.83|0.84|0.85|0.86|0.87|0.88|0.89|0.90|0.91|0.92|0.93|0.94|0.95|0.96|0.97|0.98|0.99|1.00|1.01|1.02|1.03|1.04|1.05|1.06|1.07|1.08|1.09|1.10|1.11|1.12|1.13|1.14|1.15|1.16|1.17|1.18|1.19|1.20|1.21|1.22|1.23|1.24|1.25" default="1"/>
+		<setting label="30016" type="select" id="pcsx_rearmed_dithering" values="enabled|disabled" default="enabled"/>
+		<setting label="30017" type="select" id="pcsx_rearmed_drc" values="enabled|disabled" default="enabled"/>
+		<setting label="30018" type="select" id="pcsx_rearmed_duping_enable" values="enabled|disabled" default="enabled"/>
+		<setting label="30019" type="select" id="pcsx_rearmed_display_internal_fps" values="disabled|enabled" default="disabled"/>
+		<setting label="30020" type="select" id="pcsx_rearmed_gpu_peops_odd_even_bit" values="disabled|enabled" default="disabled"/>
+		<setting label="30021" type="select" id="pcsx_rearmed_gpu_peops_expand_screen_width" values="disabled|enabled" default="disabled"/>
+		<setting label="30022" type="select" id="pcsx_rearmed_gpu_peops_ignore_brightness" values="disabled|enabled" default="disabled"/>
+		<setting label="30023" type="select" id="pcsx_rearmed_gpu_peops_disable_coord_check" values="disabled|enabled" default="disabled"/>
+		<setting label="30024" type="select" id="pcsx_rearmed_gpu_peops_lazy_screen_update" values="disabled|enabled" default="disabled"/>
+		<setting label="30025" type="select" id="pcsx_rearmed_gpu_peops_old_frame_skip" values="enabled|disabled" default="enabled"/>
+		<setting label="30026" type="select" id="pcsx_rearmed_gpu_peops_repeated_triangles" values="disabled|enabled" default="disabled"/>
+		<setting label="30027" type="select" id="pcsx_rearmed_gpu_peops_quads_with_triangles" values="disabled|enabled" default="disabled"/>
+		<setting label="30028" type="select" id="pcsx_rearmed_gpu_peops_fake_busy_state" values="disabled|enabled" default="disabled"/>
+		<setting label="30029" type="select" id="pcsx_rearmed_gpu_thread_rendering" values="disabled|sync|async" default="disabled"/>
+		<setting label="30030" type="select" id="pcsx_rearmed_show_bios_bootlogo" values="disabled|enabled" default="disabled"/>
+		<setting label="30031" type="select" id="pcsx_rearmed_spu_reverb" values="enabled|disabled" default="enabled"/>
+		<setting label="30032" type="select" id="pcsx_rearmed_spu_interpolation" values="simple|gaussian|cubic|off" default="simple"/>
+		<setting label="30033" type="select" id="pcsx_rearmed_idiablofix" values="disabled|enabled" default="disabled"/>
+		<setting label="30034" type="select" id="pcsx_rearmed_pe2_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30035" type="select" id="pcsx_rearmed_inuyasha_fix" values="disabled|enabled" default="disabled"/>
+		<setting label="30036" type="select" id="pcsx_rearmed_async_cd" values="sync|async|precache" default="sync"/>
+		<setting label="30037" type="select" id="pcsx_rearmed_noxadecoding" values="enabled|disabled" default="enabled"/>
+		<setting label="30038" type="select" id="pcsx_rearmed_nocdaudio" values="enabled|disabled" default="enabled"/>
+		<setting label="30039" type="select" id="pcsx_rearmed_spuirq" values="disabled|enabled" default="disabled"/>
 	</category>
 </settings>


### PR DESCRIPTION
## Description

https://github.com/kodi-game/game.libretro.pcsx-rearmed/pull/20 was auto-closed, so I have to re-open.

This time with an updated patch and non-sorted settings.

Original description:

In this core, certain settings are disabled at compile-time. Because we generate settings on one machine for all platforms, let's just include settings for all platforms. This is the "quick and easy solution" mentioned in https://github.com/kodi-game/game.libretro.pcsx-rearmed/issues/19. My justification is that libretro settings are presented in the Kodi UI as "Advanced settings", so it's expected that the user would understand that changing a setting for a different system would have no effect.

## Related PRs

Requires https://github.com/kodi-game/kodi-game-scripting/pull/86

## How has this been tested?

See PR commits. First, I disabled sorting and generated settings. Then I uploaded the patch. Then I generated settings again, and you can see that the initial settings remain in the same order, and new NEON/dynarec settings are injected.
