### PR TITLE
topology.xml: Flatten ports to handle options-based multitaps

### DIFF
--- a/game.libretro.pcsx-rearmed/resources/topology.xml
+++ b/game.libretro.pcsx-rearmed/resources/topology.xml
@@ -1,91 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <logicaltopology>
 	<port type="controller" id="1">
+		<accepts controller="game.controller.ps.gamepad"/>
 		<accepts controller="game.controller.ps.dualanalog"/>
 		<accepts controller="game.controller.ps.dualshock"/>
-		<accepts controller="game.controller.ps.gamepad"/>
 		<accepts controller="game.controller.ps.guncon.western"/>
 		<accepts controller="game.controller.ps.guncon.japan"/>
 		<accepts controller="game.controller.ps.mouse"/>
-		<!-- TODO: Multitap uses libretro options API for configuration
-		<accepts controller="game.controller.ps.multitap">
-			<port type="controller" id="1">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="2">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="3">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="4">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-		</accepts>
-		-->
 	</port>
 	<port type="controller" id="2">
+		<accepts controller="game.controller.ps.gamepad"/>
 		<accepts controller="game.controller.ps.dualanalog"/>
 		<accepts controller="game.controller.ps.dualshock"/>
-		<accepts controller="game.controller.ps.gamepad"/>
 		<accepts controller="game.controller.ps.guncon.western"/>
 		<accepts controller="game.controller.ps.guncon.japan"/>
 		<accepts controller="game.controller.ps.mouse"/>
-		<!-- TODO: Multitap uses libretro options API for configuration
-		<accepts controller="game.controller.ps.multitap">
-			<port type="controller" id="1">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="2">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="3">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-			<port type="controller" id="4">
-				<accepts controller="game.controller.ps.dualanalog"/>
-				<accepts controller="game.controller.ps.dualshock"/>
-				<accepts controller="game.controller.ps.gamepad"/>
-				<accepts controller="game.controller.ps.guncon.western"/>
-				<accepts controller="game.controller.ps.guncon.japan"/>
-				<accepts controller="game.controller.ps.mouse"/>
-			</port>
-		</accepts>
-		-->
+	</port>
+	<port type="controller" id="3">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
+	</port>
+	<port type="controller" id="4">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
+	</port>
+	<port type="controller" id="5">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
+	</port>
+	<port type="controller" id="6">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
+	</port>
+	<port type="controller" id="7">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
+	</port>
+	<port type="controller" id="8">
+		<accepts controller="game.controller.ps.gamepad"/>
+		<accepts controller="game.controller.ps.dualanalog"/>
+		<accepts controller="game.controller.ps.dualshock"/>
+		<accepts controller="game.controller.ps.guncon.western"/>
+		<accepts controller="game.controller.ps.guncon.japan"/>
+		<accepts controller="game.controller.ps.mouse"/>
 	</port>
 </logicaltopology>


### PR DESCRIPTION
Also moves the non-analog gamepad to the default spot. See discussion here: https://forum.kodi.tv/showthread.php?tid=295463&pid=3066312#pid3066312

The new topology.xml file is:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<logicaltopology>
	<port type="controller" id="1">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="2">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="3">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="4">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="5">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="6">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="7">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
	<port type="controller" id="8">
		<accepts controller="game.controller.ps.gamepad"/>
		<accepts controller="game.controller.ps.dualanalog"/>
		<accepts controller="game.controller.ps.dualshock"/>
		<accepts controller="game.controller.ps.guncon.western"/>
		<accepts controller="game.controller.ps.guncon.japan"/>
		<accepts controller="game.controller.ps.mouse"/>
	</port>
</logicaltopology>
```