### PR TITLE
Update settings patch to latest master

### DIFF
--- a/depends/common/pcsx-rearmed/0001-Force-enable-all-settings.patch
+++ b/depends/common/pcsx-rearmed/0001-Force-enable-all-settings.patch
@@ -1,14 +1,14 @@
-From 3ed903fd9940e07ee5b8a4877e99cf3659346a14 Mon Sep 17 00:00:00 2001
+From d2dc905e2bb4498ea77476156a3213b16b15d557 Mon Sep 17 00:00:00 2001
 From: Garrett Brown <themagnificentmrb@gmail.com>
-Date: Sat, 29 Jan 2022 11:18:43 -0800
+Date: Tue, 5 Dec 2023 14:37:09 -0800
 Subject: [PATCH] Force-enable all settings
 
 ---
- frontend/libretro_core_options.h | 20 --------------------
- 1 file changed, 20 deletions(-)
+ frontend/libretro_core_options.h | 22 ----------------------
+ 1 file changed, 22 deletions(-)
 
 diff --git a/frontend/libretro_core_options.h b/frontend/libretro_core_options.h
-index 58e1b72..3537091 100644
+index a0cd2ac1..f3f042fa 100644
 --- a/frontend/libretro_core_options.h
 +++ b/frontend/libretro_core_options.h
 @@ -61,27 +61,21 @@ struct retro_core_option_v2_category option_cats_us[] = {
@@ -69,15 +69,15 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_psxclock",
        "PSX CPU Clock Speed",
-@@ -326,7 +316,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
-       },
+@@ -309,7 +299,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        "enabled",
+ #endif
     },
 -#ifdef THREAD_RENDERING
     {
        "pcsx_rearmed_gpu_thread_rendering",
        "Threaded Rendering",
-@@ -342,7 +331,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -325,7 +314,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        },
        "disabled",
     },
@@ -85,15 +85,15 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_frameskip_type",
        "Frameskip",
-@@ -438,7 +426,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
-       },
-       "auto",
+@@ -466,7 +454,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       "0",
     },
+ #undef V
 -#ifdef GPU_NEON
     {
-       "pcsx_rearmed_neon_interlace_enable",
+       "pcsx_rearmed_neon_interlace_enable_v2",
        "(GPU) Show Interlaced Video",
-@@ -481,8 +468,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -510,8 +497,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        },
        "disabled",
     },
@@ -102,7 +102,7 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_show_gpu_peops_settings",
        "Show Advanced P.E.Op.S. GPU Settings",
-@@ -609,8 +594,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -638,8 +623,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        },
        "disabled",
     },
@@ -111,7 +111,7 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_show_gpu_unai_settings",
        "Show Advanced UNAI GPU Settings",
-@@ -685,7 +668,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -714,7 +697,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        "disabled",
  #endif
     },
@@ -119,7 +119,23 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_spu_reverb",
        "Audio Reverb Effects",
-@@ -1167,7 +1149,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -781,7 +763,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       },
+       "enabled",
+    },
+-#if P_HAVE_PTHREAD
+    {
+       "pcsx_rearmed_spu_thread",
+       "Threaded SPU",
+@@ -796,7 +777,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       },
+       "disabled",
+    },
+-#endif // P_HAVE_PTHREAD
+    {
+       "pcsx_rearmed_show_input_settings",
+       "Show Input Settings",
+@@ -1524,7 +1504,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        },
        "disabled",
     },
@@ -127,14 +143,14 @@ index 58e1b72..3537091 100644
     {
        "pcsx_rearmed_nocompathacks",
        "Disable Automatic Compatibility Hacks",
-@@ -1238,7 +1219,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+@@ -1581,7 +1560,6 @@ struct retro_core_option_v2_definition option_defs_us[] = {
        },
        "disabled",
     },
 -#endif /* !DRC_DISABLE && !LIGHTREC */
-    { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
- };
- 
+    {
+       "pcsx_rearmed_nostalls",
+       "Disable CPU/GTE Stalls",
 -- 
-2.34.1
+2.37.0.windows.1
 


### PR DESCRIPTION
Fixes build error on [latest CI run](https://dev.azure.com/themagnificentmrb/kodi-game-scripting/_build/results?buildId=1270&view=logs&j=b724a4ce-d971-5e6e-9f98-76134d834be3&t=ceca6bbb-3580-576a-9e78-bc4888f75d58):

```
[ 23%] Performing patch step for 'pcsx-rearmed'
patching file frontend/libretro_core_options.h
Hunk #5 succeeded at 299 with fuzz 2 (offset -17 lines).
Hunk #6 succeeded at 314 (offset -17 lines).
Hunk #7 FAILED at 426.
Hunk #8 succeeded at 498 (offset 29 lines).
Hunk #9 succeeded at 624 (offset 29 lines).
Hunk #10 succeeded at 698 (offset 29 lines).
Hunk #11 succeeded at 1507 (offset 357 lines).
Hunk #12 FAILED at 1220.
2 out of 12 hunks FAILED -- saving rejects to file frontend/libretro_core_options.h.rej
gmake[2]: *** [CMakeFiles/pcsx-rearmed.dir/build.make:115: build/pcsx-rearmed/src/pcsx-rearmed-stamp/pcsx-rearmed-patch] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:158: CMakeFiles/pcsx-rearmed.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```